### PR TITLE
refactor: move sliders to a component

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.nuxt/
+.yarn/
+.output/
+dist/
+node_modules/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,10 +4,10 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
+    spec: '@yarnpkg/plugin-typescript'
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
+    spec: '@yarnpkg/plugin-workspace-tools'
 
 yarnPath: .yarn/releases/yarn-3.5.1.cjs

--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,7 @@
 <template>
+	<vite-pwa-manifest />
+	<nuxt-loading-indicator />
 	<nuxt-layout name="main">
-		<vite-pwa-manifest />
-		<nuxt-loading-indicator />
 		<nuxt-page />
 	</nuxt-layout>
 </template>

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -11,7 +11,6 @@
 	a {
 		@apply underline-offset-2;
 	}
-
 }
 
 @layer components {

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -24,6 +24,10 @@
 	}
 
 	.base-input {
-		@apply border-2 p-2 bg-gray-100 border-gray-300 dark:border-stone-700 dark:bg-stone-900 dark:[color-scheme:dark];
+		@apply border-2 p-2 bg-gray-100 border-gray-300 dark:border-stone-700 dark:bg-stone-900;
+	}
+
+	input {
+		@apply dark:[color-scheme:dark];
 	}
 }

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -22,4 +22,8 @@
 	::-webkit-scrollbar-thumb {
 		@apply bg-gray-200 hover:bg-gray-300 dark:bg-stone-900 hover:dark:bg-stone-800 rounded-xl;
 	}
+
+	.base-input {
+		@apply border-2 p-2 bg-gray-100 border-gray-300 dark:border-stone-700 dark:bg-stone-900 dark:[color-scheme:dark];
+	}
 }

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -1,0 +1,13 @@
+<template>
+	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status">
+		<code>
+{{formattedJson}}
+		</code>
+	</pre>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ data: object }>();
+
+const formattedJson = computed(() => JSON.stringify(props.data, null, '\t'));
+</script>

--- a/components/input-slider.vue
+++ b/components/input-slider.vue
@@ -1,0 +1,28 @@
+<template>
+	<label>
+		{{ name
+		}}<span role="status" class="before:content-[':_'] opacity-80" :aria-hidden="type === 'number'" v-show="type === 'range'">
+			<slot name="header" :value="modelValue">{{ modelValue }}</slot>
+		</span>
+		<input
+			v-bind="$attrs"
+			:type="type"
+			:value="modelValue"
+			@input="$emit('update:modelValue', ($event.target as HTMLInputElement).valueAsNumber)"
+			class="base-input range w-full"
+		/>
+	</label>
+</template>
+
+<script lang="ts">
+export default {
+	inheritAttrs: false
+};
+</script>
+
+<script setup lang="ts">
+defineProps<{ name: string; modelValue: number; type: 'number' | 'range' }>();
+defineEmits<{
+	(event: 'update:modelValue', value: number): void;
+}>();
+</script>

--- a/components/input-slider.vue
+++ b/components/input-slider.vue
@@ -1,7 +1,9 @@
 <template>
 	<label>
-		{{ name
-		}}<span role="status" class="before:content-[':_'] opacity-80" :aria-hidden="type === 'number'" v-show="type === 'range'">
+		<span :class="{ 'after:content-[\':_\'] after:opacity-80': type === 'range' }">
+			{{ name }}
+		</span>
+		<span role="status" class="opacity-80" :aria-hidden="type === 'number'" v-show="type === 'range'">
 			<slot name="header" :value="modelValue">{{ modelValue }}</slot>
 		</span>
 		<input

--- a/components/input-slider.vue
+++ b/components/input-slider.vue
@@ -9,7 +9,7 @@
 			:type="type"
 			:value="modelValue"
 			@input="$emit('update:modelValue', ($event.target as HTMLInputElement).valueAsNumber)"
-			class="base-input range w-full"
+			class="base-input rounded w-full"
 		/>
 	</label>
 </template>

--- a/components/input-slider.vue
+++ b/components/input-slider.vue
@@ -1,9 +1,7 @@
 <template>
 	<label>
-		<span :class="{ 'after:content-[\':_\'] after:opacity-80': type === 'range' }">
-			{{ name }}
-		</span>
-		<span role="status" class="opacity-80" :aria-hidden="type === 'number'" v-show="type === 'range'">
+		<span>{{ name }}</span>
+		<span role="status" class="before:content-[':_'] opacity-80" :aria-hidden="type === 'number'" v-show="type === 'range'">
 			<slot name="header" :value="modelValue">{{ modelValue }}</slot>
 		</span>
 		<input

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,0 +1,31 @@
+import type { reactive } from 'vue';
+
+export interface EntryBox {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	rotation: number;
+	modifiers: EntryBoxModifiers;
+}
+
+export interface EntryAvatarPosition {
+	x: number;
+	y: number;
+	size: number;
+	style: 'circle' | 'square';
+	rotation: number;
+}
+
+interface EntryBoxModifiers {
+	font: 'impact' | 'arial';
+	fontSize: number;
+	allCaps: boolean;
+	bold: boolean;
+	italic: boolean;
+	outlineType: 'shadow' | 'outline' | 'none';
+	outlineWidth: number;
+	textAlign: 'left' | 'center' | 'right';
+	verticalAlign: 'top' | 'middle' | 'bottom';
+	opacity: number;
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -59,9 +59,22 @@ const manifestIcons = [
 const name = 'Meme Template Generator';
 const description = "A small but complete interactive browser utility to create new meme templates for Artiel's meme generator";
 
-// https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
 	modules: ['@vueuse/nuxt', '@nuxtjs/tailwindcss', '@vite-pwa/nuxt'],
+	nitro: {
+		preset: 'cloudflare-pages',
+		prerender: {
+			routes: ['/', '/about', '/sitemap.xml']
+		}
+	},
+	typescript: {
+		shim: false,
+		tsConfig: {
+			compilerOptions: {
+				moduleResolution: 'bundler'
+			}
+		}
+	},
 	pwa: {
 		registerType: 'autoUpdate',
 		devOptions: {
@@ -94,14 +107,6 @@ export default defineNuxtConfig({
 					icons: manifestIcons
 				}
 			]
-		}
-	},
-	typescript: {
-		shim: false,
-		tsConfig: {
-			compilerOptions: {
-				moduleResolution: 'bundler'
-			}
 		}
 	},
 	app: {
@@ -173,12 +178,6 @@ export default defineNuxtConfig({
 				{ property: 'og:type', content: 'website' },
 				{ property: 'og:url', content: 'https://memes.skyra.pw' }
 			]
-		}
-	},
-	nitro: {
-		preset: 'cloudflare-pages',
-		prerender: {
-			routes: ['/', '/about', '/sitemap.xml']
 		}
 	}
 });

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
 		"preview": "nuxt preview",
 		"postinstall": "nuxt prepare",
 		"update": "yarn upgrade-interactive",
-		"format": "prettier --write --loglevel=warn \"{assets,components,content,layouts,pages,server}/**/*.{js,ts,json,vue,md}\" \"app.vue\" \"nuxt.config.ts\""
-	},
-	"dependencies": {
-		"canvas-constructor": "^7.0.1"
+		"format": "prettier --write ."
 	},
 	"devDependencies": {
 		"@nuxtjs/tailwindcss": "^6.7.0",
@@ -21,6 +18,7 @@
 		"@vite-pwa/nuxt": "^0.0.8",
 		"@vueuse/core": "^10.1.2",
 		"@vueuse/nuxt": "^10.1.2",
+		"canvas-constructor": "^7.0.1",
 		"nuxt": "^3.5.0",
 		"prettier": "^2.8.8",
 		"sitemap": "^7.1.1"

--- a/pages/[...id].vue
+++ b/pages/[...id].vue
@@ -245,14 +245,13 @@
 	</div>
 
 	<hr class="json-divider" />
-	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status">{{
-		JSON.stringify({ name, url, avatars, boxes }, null, '\t')
-	}}</pre>
+	<codeblock :data="{ name, url, avatars, boxes }" />
 </template>
 
 <script setup lang="ts">
 import { useImage } from '@vueuse/core';
 import { Canvas } from 'canvas-constructor/browser';
+import type { EntryAvatarPosition, EntryBox } from '~/lib/interfaces';
 
 const name = ref('');
 const url = ref('');
@@ -417,36 +416,6 @@ function printImage() {
 			if (++index > colors.length) index = 0;
 		}
 	}
-}
-
-interface EntryBox {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-	rotation: number;
-	modifiers: EntryBoxModifiers;
-}
-
-interface EntryBoxModifiers {
-	font: 'impact' | 'arial';
-	fontSize: number;
-	allCaps: boolean;
-	bold: boolean;
-	italic: boolean;
-	outlineType: 'shadow' | 'outline' | 'none';
-	outlineWidth: number;
-	textAlign: 'left' | 'center' | 'right';
-	verticalAlign: 'top' | 'middle' | 'bottom';
-	opacity: number;
-}
-
-interface EntryAvatarPosition {
-	x: number;
-	y: number;
-	size: number;
-	style: 'circle' | 'square';
-	rotation: number;
 }
 </script>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -74,23 +74,23 @@
 			<div v-for="(box, index) of boxes" class="px-4 py-2 border-l-2 rounded shadow-sm mt-5" :class="classes[index % classes.length]">
 				<h3 class="text-xl font-bold">Text #{{ index + 1 }}</h3>
 				<div class="grid grid-cols-2 gap-2 mt-2">
-					<input-slider name="X" v-model="box.x" :type="inputType" :min="0" :max="width" class="base-input range w-full">
+					<input-slider name="X" v-model="box.x" :type="inputType" :min="0" :max="width">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider name="Y" v-model="box.y" :type="inputType" :min="0" :max="height" class="base-input range w-full">
+					<input-slider name="Y" v-model="box.y" :type="inputType" :min="0" :max="height">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider name="Width" v-model="box.width" :type="inputType" :min="0" :max="width" class="base-input range w-full">
+					<input-slider name="Width" v-model="box.width" :type="inputType" :min="0" :max="width">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider name="Height" v-model="box.height" :type="inputType" :min="0" :max="height" class="base-input range w-full">
+					<input-slider name="Height" v-model="box.height" :type="inputType" :min="0" :max="height">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider name="Rotation" v-model="box.rotation" :type="inputType" :min="-180" :max="180" class="base-input range w-full">
+					<input-slider name="Rotation" v-model="box.rotation" :type="inputType" :min="-180" :max="180">
 						<template #header="{ value }">{{ value }}º</template>
 					</input-slider>
 				</div>
@@ -106,14 +106,7 @@
 							</select>
 						</label>
 
-						<input-slider
-							name="Size"
-							v-model="box.modifiers.fontSize"
-							:type="inputType"
-							:min="1"
-							:max="72"
-							class="base-input range w-full"
-						>
+						<input-slider name="Size" v-model="box.modifiers.fontSize" :type="inputType" :min="1" :max="72">
 							<template #header="{ value }">{{ value }}px</template>
 						</input-slider>
 
@@ -134,7 +127,6 @@
 							:max="4"
 							:step="0.25"
 							:disabled="box.modifiers.outlineType === 'none'"
-							class="base-input range w-full"
 						>
 							<template #header="{ value }">{{ value }}px</template>
 						</input-slider>
@@ -184,15 +176,7 @@
 							</label>
 						</div>
 
-						<input-slider
-							name="Opacity"
-							v-model="box.modifiers.opacity"
-							:type="inputType"
-							:min="0"
-							:max="1"
-							:step="0.01"
-							class="base-input range w-full"
-						>
+						<input-slider name="Opacity" v-model="box.modifiers.opacity" :type="inputType" :min="0" :max="1" :step="0.01">
 							<template #header="{ value }">{{ Math.round(value * 100) }}%</template>
 						</input-slider>
 					</div>
@@ -228,26 +212,19 @@
 					class="px-4 py-2 border-l-2 rounded shadow-sm grid grid-cols-2 gap-2"
 					:class="classes[index % classes.length]"
 				>
-					<input-slider name="X" v-model="position.x" :type="inputType" :min="0" :max="width" class="base-input range w-full">
+					<input-slider name="X" v-model="position.x" :type="inputType" :min="0" :max="width">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider name="Y" :type="inputType" v-model="position.y" :min="0" :max="height" class="base-input range w-full">
+					<input-slider name="Y" :type="inputType" v-model="position.y" :min="0" :max="height">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider name="Size" v-model="position.size" :type="inputType" :min="16" :max="height" class="base-input range w-full">
+					<input-slider name="Size" v-model="position.size" :type="inputType" :min="16" :max="height">
 						<template #header="{ value }">{{ value }}px</template>
 					</input-slider>
 
-					<input-slider
-						name="Rotation"
-						v-model="position.rotation"
-						:type="inputType"
-						:min="-180"
-						:max="180"
-						class="base-input range w-full"
-					>
+					<input-slider name="Rotation" v-model="position.rotation" :type="inputType" :min="-180" :max="180">
 						<template #header="{ value }">{{ value }}º</template>
 					</input-slider>
 
@@ -514,13 +491,5 @@ select.select:focus {
 		linear-gradient(135deg, var(--tw-select-bg-color) 50%, var(--tw-select-arrow-color) 50%);
 	background-position: calc(100% - 15px) 1em, calc(100% - 20px) 1em;
 	background-size: 5px 5px, 5px 5px;
-}
-
-input.range {
-	@apply rounded dark:[color-scheme:dark];
-}
-
-input.checkbox {
-	@apply dark:[color-scheme:dark];
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,17 +1,17 @@
 <template>
 	<div>
 		<label class="block mb-5">
-			<span>Name</span>
+			Name
 			<input type="text" v-model.trim="name" class="base-input rounded w-full" />
 		</label>
 
 		<label class="block mb-5">
-			<span>URL</span>
+			URL
 			<input type="url" v-model.trim="url" class="base-input rounded w-full" />
 		</label>
 
 		<label class="flex mb-5 items-center gap-2">
-			<span>Use number input instead of sliders:</span>
+			Use number input instead of sliders:
 			<input type="checkbox" :value="inputType === 'number'" @change.prevent="toggleInputType()" class="checkbox" />
 		</label>
 	</div>
@@ -29,12 +29,12 @@
 				clip-rule="evenodd"
 			></path>
 		</svg>
-		<span>
+		<p>
 			Please fill the above input box with a link to an image to load as a base for the new meme template, for example,
 			<NuxtLink href="https://skyra.pw/avatars/skyra.png" target="_blank" class="underline opacity-80">
 				https://skyra.pw/avatars/skyra.png</NuxtLink
 			>.
-		</span>
+		</p>
 	</div>
 	<div v-else-if="error || !imageData.src" class="mb-4 flex rounded-lg bg-opacity-25 p-4 text-sm bg-red-500" role="alert">
 		<svg
@@ -49,9 +49,9 @@
 				clip-rule="evenodd"
 			></path>
 		</svg>
-		<span>
+		<p>
 			{{ error ? 'The URL you have provided could not be loaded.' : 'The URL you have provided is not a valid image URL.' }}
-		</span>
+		</p>
 	</div>
 
 	<div class="grid grid-flow-row lg:grid-cols-[1fr_416px] xl:grid-cols-[1fr_416px_1fr] gap-4 mb-5 w-full justify-items-center">
@@ -99,7 +99,7 @@
 					<template #header>Details</template>
 					<div class="grid grid-cols-2 gap-2 px-2 py-1 mt-2 mb-3 bg-gray-200 dark:bg-stone-900 rounded-xl">
 						<label>
-							<span>Font</span>
+							Font
 							<select v-model="box.modifiers.font" class="base-input select rounded w-full">
 								<option value="impact">Impact</option>
 								<option value="arial">Arial</option>
@@ -111,7 +111,7 @@
 						</input-slider>
 
 						<label>
-							<span>Outline Type</span>
+							Outline Type
 							<select v-model="box.modifiers.outlineType" class="base-input select rounded w-full">
 								<option value="outline">Outline</option>
 								<option value="shadow">Shadow</option>
@@ -132,7 +132,7 @@
 						</input-slider>
 
 						<label>
-							<span>Text Align</span>
+							Text Align
 							<select v-model="box.modifiers.textAlign" class="base-input select rounded w-full">
 								<option value="left">Left</option>
 								<option value="center">Center</option>
@@ -141,7 +141,7 @@
 						</label>
 
 						<label>
-							<span>Vertical Align</span>
+							Vertical Align
 							<select v-model="box.modifiers.verticalAlign" class="base-input select rounded w-full">
 								<option value="top">Top</option>
 								<option value="middle">Middle</option>
@@ -162,17 +162,17 @@
 
 							<label class="flex items-center gap-2">
 								<input type="checkbox" v-model="box.modifiers.allCaps" class="checkbox" />
-								<span>All Caps</span>
+								All Caps
 							</label>
 
 							<label class="flex items-center gap-2">
 								<input type="checkbox" v-model="box.modifiers.bold" class="checkbox" />
-								<span>Bold</span>
+								Bold
 							</label>
 
 							<label class="flex items-center gap-2">
 								<input type="checkbox" v-model="box.modifiers.italic" class="checkbox" />
-								<span>Italic</span>
+								Italic
 							</label>
 						</div>
 
@@ -229,7 +229,7 @@
 					</input-slider>
 
 					<label>
-						<span>Style</span>
+						Style
 						<select v-model="position.style" class="base-input select rounded w-full">
 							<option value="circle">Circle</option>
 							<option value="square">Square</option>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -74,40 +74,25 @@
 			<div v-for="(box, index) of boxes" class="px-4 py-2 border-l-2 rounded shadow-sm mt-5" :class="classes[index % classes.length]">
 				<h3 class="text-xl font-bold">Text #{{ index + 1 }}</h3>
 				<div class="grid grid-cols-2 gap-2 mt-2">
-					<label>
-						<span>
-							X<span class="status" role="status">: {{ box.x }}px</span>
-						</span>
-						<input :type="inputType" min="0" :max="width" v-model.number="box.x" class="base-input range w-full" />
-					</label>
+					<input-slider name="X" v-model="box.x" :type="inputType" :min="0" :max="width" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Y<span class="status" role="status">: {{ box.y }}px</span>
-						</span>
-						<input :type="inputType" min="0" :max="height" v-model.number="box.y" class="base-input range w-full" />
-					</label>
+					<input-slider name="Y" v-model="box.y" :type="inputType" :min="0" :max="height" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Width<span class="status" role="status">: {{ box.width }}px</span>
-						</span>
-						<input :type="inputType" min="20" :max="width" v-model.number="box.width" class="base-input range w-full" />
-					</label>
+					<input-slider name="Width" v-model="box.width" :type="inputType" :min="0" :max="width" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Height<span class="status" role="status">: {{ box.height }}px</span>
-						</span>
-						<input :type="inputType" min="20" :max="height" v-model.number="box.height" class="base-input range w-full" />
-					</label>
+					<input-slider name="Height" v-model="box.height" :type="inputType" :min="0" :max="height" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Rotation<span class="status" role="status">: {{ box.rotation }}º</span>
-						</span>
-						<input :type="inputType" min="-180" max="180" v-model.number="box.rotation" class="base-input range w-full" />
-					</label>
+					<input-slider name="Rotation" v-model="box.rotation" :type="inputType" :min="-180" :max="180" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}º</template>
+					</input-slider>
 				</div>
 
 				<accordion class="bg-gray-300 dark:bg-stone-950 px-1 py-2 rounded-xl mt-2">
@@ -121,12 +106,16 @@
 							</select>
 						</label>
 
-						<label>
-							<span>
-								Size<span class="status" role="status">: {{ box.modifiers.fontSize }}px</span>
-							</span>
-							<input :type="inputType" min="1" max="72" v-model.number="box.modifiers.fontSize" class="base-input range w-full" />
-						</label>
+						<input-slider
+							name="Size"
+							v-model="box.modifiers.fontSize"
+							:type="inputType"
+							:min="1"
+							:max="72"
+							class="base-input range w-full"
+						>
+							<template #header="{ value }">{{ value }}px</template>
+						</input-slider>
 
 						<label>
 							<span>Outline Type</span>
@@ -137,20 +126,18 @@
 							</select>
 						</label>
 
-						<label>
-							<span>
-								Width<span class="status" role="status">: {{ box.modifiers.outlineWidth }}px</span>
-							</span>
-							<input
-								:type="inputType"
-								min="0"
-								max="4"
-								step="0.25"
-								v-model.number="box.modifiers.outlineWidth"
-								:disabled="box.modifiers.outlineType === 'none'"
-								class="base-input range w-full"
-							/>
-						</label>
+						<input-slider
+							name="Width"
+							v-model="box.modifiers.outlineWidth"
+							:type="inputType"
+							:min="0"
+							:max="4"
+							:step="0.25"
+							:disabled="box.modifiers.outlineType === 'none'"
+							class="base-input range w-full"
+						>
+							<template #header="{ value }">{{ value }}px</template>
+						</input-slider>
 
 						<label>
 							<span>Text Align</span>
@@ -171,17 +158,16 @@
 						</label>
 
 						<div>
-							Modifiers<span class="status"
-								>:
-								<span
-									:class="{
-										uppercase: box.modifiers.allCaps,
-										italic: box.modifiers.italic,
-										'font-extrabold': box.modifiers.bold
-									}"
-									>Ab</span
-								></span
+							Modifiers<span
+								:class="{
+									uppercase: box.modifiers.allCaps,
+									italic: box.modifiers.italic,
+									'font-extrabold': box.modifiers.bold
+								}"
+								class="before:content-[':_'] before:font-medium before:not-italic opacity-80"
+								>Ab</span
 							>
+
 							<label class="flex items-center gap-2">
 								<input type="checkbox" v-model="box.modifiers.allCaps" class="checkbox" />
 								<span>All Caps</span>
@@ -198,19 +184,17 @@
 							</label>
 						</div>
 
-						<label>
-							<span>
-								Opacity<span class="status" role="status">: {{ Math.round(box.modifiers.opacity * 100) }}%</span>
-							</span>
-							<input
-								:type="inputType"
-								min="0"
-								max="1"
-								step="0.01"
-								v-model.number="box.modifiers.opacity"
-								class="base-input range w-full"
-							/>
-						</label>
+						<input-slider
+							name="Opacity"
+							v-model="box.modifiers.opacity"
+							:type="inputType"
+							:min="0"
+							:max="1"
+							:step="0.01"
+							class="base-input range w-full"
+						>
+							<template #header="{ value }">{{ Math.round(value * 100) }}%</template>
+						</input-slider>
 					</div>
 				</accordion>
 
@@ -244,33 +228,28 @@
 					class="px-4 py-2 border-l-2 rounded shadow-sm grid grid-cols-2 gap-2"
 					:class="classes[index % classes.length]"
 				>
-					<label>
-						<span>
-							X<span class="status" role="status">: {{ position.x }}px</span>
-						</span>
-						<input :type="inputType" min="0" :max="width" v-model.number="position.x" class="base-input range w-full" />
-					</label>
+					<input-slider name="X" v-model="position.x" :type="inputType" :min="0" :max="width" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Y<span class="status" role="status">: {{ position.y }}px</span>
-						</span>
-						<input :type="inputType" min="0" :max="height" v-model.number="position.y" class="base-input range w-full" />
-					</label>
+					<input-slider name="Y" :type="inputType" v-model="position.y" :min="0" :max="height" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Size<span class="status" role="status">: {{ position.size }}px</span>
-						</span>
-						<input :type="inputType" min="16" :max="height" v-model.number="position.size" class="base-input range w-full" />
-					</label>
+					<input-slider name="Size" v-model="position.size" :type="inputType" :min="16" :max="height" class="base-input range w-full">
+						<template #header="{ value }">{{ value }}px</template>
+					</input-slider>
 
-					<label>
-						<span>
-							Rotation<span class="status" role="status">: {{ position.rotation }}º</span>
-						</span>
-						<input :type="inputType" min="-180" max="180" v-model.number="position.rotation" class="base-input range w-full" />
-					</label>
+					<input-slider
+						name="Rotation"
+						v-model="position.rotation"
+						:type="inputType"
+						:min="-180"
+						:max="180"
+						class="base-input range w-full"
+					>
+						<template #header="{ value }">{{ value }}º</template>
+					</input-slider>
 
 					<label>
 						<span>Style</span>
@@ -512,10 +491,6 @@ button.danger {
 	@apply text-gray-50 bg-red-600 dark:bg-red-700;
 }
 
-.base-input {
-	@apply border-2 p-2 bg-gray-100 border-gray-300 dark:border-stone-700 dark:bg-stone-900 dark:[color-scheme:dark];
-}
-
 select.select {
 	--tw-border-opacity: 1;
 	--tw-select-arrow-rgb: 209 213 219;
@@ -547,9 +522,5 @@ input.range {
 
 input.checkbox {
 	@apply dark:[color-scheme:dark];
-}
-
-span.status {
-	@apply text-stone-600 dark:text-stone-400;
 }
 </style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+	// https://nuxt.com/docs/guide/concepts/typescript
+	"extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
I also reduced the amount of elements and leveraged `before:content` to not require double nested `<span>`s, reducing the amount of elements in the website.