### PR TITLE
feat: add TSX-powered codeblock

### DIFF
--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -88,9 +88,9 @@ function addBoxes(lines: JSX.Element[], boxes: readonly EntryBox[]) {
 
 function renderJson() {
 	const url = (
-		<nuxt-link target="_blank" href={props.url} class="underline">
+		<a target="_blank" href={props.url} rel="noopener noreferrer" class="underline">
 			{props.url}
-		</nuxt-link>
+		</a>
 	);
 	const lines = [
 		line(0, brace(0, '{')),

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -1,13 +1,121 @@
 <template>
-	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status">
-		<code>
-{{formattedJson}}
-		</code>
-	</pre>
+	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status"><render-json /></pre>
 </template>
 
-<script setup lang="ts">
-const props = defineProps<{ data: object }>();
+<script setup lang="tsx">
+import type { EntryAvatarPosition, EntryBox } from '~/lib/interfaces';
 
-const formattedJson = computed(() => JSON.stringify(props.data, null, '\t'));
+const props = defineProps<{
+	name: string;
+	url: string;
+	avatars: { author: readonly EntryAvatarPosition[]; target: readonly EntryAvatarPosition[] };
+	boxes: readonly EntryBox[];
+}>();
+
+function line(indent: number, ...elements: readonly (JSX.Element | string)[]) {
+	return (
+		<span class="block">
+			{'\t'.repeat(indent)}
+			{elements}
+		</span>
+	);
+}
+
+function property(name: string) {
+	return <span class="text-teal-400">"{name}"</span>;
+}
+
+function string(value: string) {
+	return <span class="text-green-400">"{value}"</span>;
+}
+
+function number(value: number) {
+	return <span class="text-amber-400">{value}</span>;
+}
+
+function boolean(value: boolean) {
+	return <span class="text-rose-400">{value ? 'true' : 'false'}</span>;
+}
+
+function addAvatar(lines: JSX.Element[], position: EntryAvatarPosition, last: boolean) {
+	lines.push(line(3, '{'));
+	lines.push(line(4, property('x'), ': ', number(position.x), ','));
+	lines.push(line(4, property('y'), ': ', number(position.y), ','));
+	lines.push(line(4, property('size'), ': ', number(position.size), ','));
+	lines.push(line(4, property('style'), ': ', string(position.style), ','));
+	lines.push(line(4, property('rotation'), ': ', number(position.rotation)));
+	lines.push(line(3, last ? '}' : '},'));
+}
+
+function addAvatars(lines: JSX.Element[], positions: readonly EntryAvatarPosition[]) {
+	for (let i = 0, l = positions.length - 1; i < positions.length; ++i) {
+		addAvatar(lines, positions[i], i === l);
+	}
+}
+
+function addBox(lines: JSX.Element[], box: EntryBox, last: boolean) {
+	lines.push(line(2, '{'));
+	lines.push(line(3, property('x'), ': ', number(box.x), ','));
+	lines.push(line(3, property('y'), ': ', number(box.y), ','));
+	lines.push(line(3, property('width'), ': ', number(box.width), ','));
+	lines.push(line(3, property('height'), ': ', number(box.height), ','));
+	lines.push(line(3, property('rotation'), ': ', number(box.rotation), ','));
+	lines.push(line(3, property('modifiers'), ': {'));
+	lines.push(line(4, property('font'), ': ', string(box.modifiers.font), ','));
+	lines.push(line(4, property('fontSize'), ': ', number(box.modifiers.fontSize), ','));
+	lines.push(line(4, property('allCaps'), ': ', boolean(box.modifiers.allCaps), ','));
+	lines.push(line(4, property('bold'), ': ', boolean(box.modifiers.bold), ','));
+	lines.push(line(4, property('italic'), ': ', boolean(box.modifiers.italic), ','));
+	lines.push(line(4, property('outlineType'), ': ', string(box.modifiers.outlineType), ','));
+	lines.push(line(4, property('outlineWidth'), ': ', number(box.modifiers.outlineWidth), ','));
+	lines.push(line(4, property('textAlign'), ': ', string(box.modifiers.textAlign), ','));
+	lines.push(line(4, property('verticalAlign'), ': ', string(box.modifiers.verticalAlign), ','));
+	lines.push(line(4, property('opacity'), ': ', number(box.modifiers.opacity)));
+	lines.push(line(3, '}'));
+	lines.push(line(2, last ? '}' : '},'));
+}
+
+function addBoxes(lines: JSX.Element[], boxes: readonly EntryBox[]) {
+	for (let i = 0, l = boxes.length - 1; i < boxes.length; ++i) {
+		addBox(lines, boxes[i], i === l);
+	}
+}
+
+function renderJson() {
+	const lines = [
+		line(0, '{'),
+		line(1, property('name'), ': ', string(props.name), ','),
+		line(1, property('url'), ': ', string(props.url), ','),
+		line(1, property('avatars'), ': {')
+	];
+
+	if (props.avatars.author.length === 0) {
+		lines.push(line(2, property('author'), ': [],'));
+	} else {
+		lines.push(line(2, property('author'), ': ['));
+		addAvatars(lines, props.avatars.author);
+		lines.push(line(2, '],'));
+	}
+
+	if (props.avatars.target.length === 0) {
+		lines.push(line(2, property('target'), ': []'));
+	} else {
+		lines.push(line(2, property('target'), ': []'));
+		addAvatars(lines, props.avatars.target);
+		lines.push(line(2, ']'));
+	}
+
+	lines.push(line(1, '}'));
+
+	if (props.boxes.length === 0) {
+		lines.push(line(1, property('boxes'), ': []'));
+	} else {
+		lines.push(line(1, property('boxes'), ': ['));
+		addBoxes(lines, props.boxes);
+		lines.push(line(1, ']'));
+	}
+
+	lines.push(line(0, '}'));
+	return <code>{lines}</code>;
+}
 </script>

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -1,5 +1,5 @@
 <template>
-	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status"><client-only><render-json /></client-only></pre>
+	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-auto" role="status"><client-only><render-json /></client-only></pre>
 </template>
 
 <script setup lang="tsx">
@@ -22,29 +22,34 @@ function line(indent: number, ...elements: readonly (JSX.Element | string)[]) {
 }
 
 function property(name: string) {
-	return <span class="text-teal-600 dark:text-teal-400">"{name}"</span>;
+	return <span class="text-[#bc2b3d] dark:text-[#df6a73]">"{name}"</span>;
 }
 
-function string(value: string) {
-	return <span class="text-green-600 dark:text-green-400">"{value}"</span>;
+function string(value: string | JSX.Element) {
+	return <span class="text-[#457400] dark:text-[#98c379]">"{value}"</span>;
 }
 
 function number(value: number) {
-	return <span class="text-amber-600 dark:text-amber-400">{value}</span>;
+	return <span class="text-[#915c00] dark:text-[#d19a66]">{value}</span>;
 }
 
 function boolean(value: boolean) {
-	return <span class="text-rose-600 dark:text-rose-400">{value ? 'true' : 'false'}</span>;
+	return <span class="text-[#915c00] dark:text-[#d19a66]">{value ? 'true' : 'false'}</span>;
+}
+
+const colours = ['text-[#915c00] dark:text-[#d19a66]', 'text-[#a626a4] dark:text-[#c678dd]', 'text-[#00737d] dark:text-[#56b6c2]'];
+function brace(level: number, value: '{' | '{}' | '}' | '[' | '[]' | ']') {
+	return <span class={colours[level % colours.length]}>{value}</span>;
 }
 
 function addAvatar(lines: JSX.Element[], position: EntryAvatarPosition, last: boolean) {
-	lines.push(line(3, '{'));
+	lines.push(line(3, brace(3, '{')));
 	lines.push(line(4, property('x'), ': ', number(position.x), ','));
 	lines.push(line(4, property('y'), ': ', number(position.y), ','));
 	lines.push(line(4, property('size'), ': ', number(position.size), ','));
 	lines.push(line(4, property('style'), ': ', string(position.style), ','));
 	lines.push(line(4, property('rotation'), ': ', number(position.rotation)));
-	lines.push(line(3, last ? '}' : '},'));
+	lines.push(line(3, ...(last ? [brace(3, '}')] : [brace(3, '}'), ','])));
 }
 
 function addAvatars(lines: JSX.Element[], positions: readonly EntryAvatarPosition[]) {
@@ -54,13 +59,13 @@ function addAvatars(lines: JSX.Element[], positions: readonly EntryAvatarPositio
 }
 
 function addBox(lines: JSX.Element[], box: EntryBox, last: boolean) {
-	lines.push(line(2, '{'));
+	lines.push(line(2, brace(2, '{')));
 	lines.push(line(3, property('x'), ': ', number(box.x), ','));
 	lines.push(line(3, property('y'), ': ', number(box.y), ','));
 	lines.push(line(3, property('width'), ': ', number(box.width), ','));
 	lines.push(line(3, property('height'), ': ', number(box.height), ','));
 	lines.push(line(3, property('rotation'), ': ', number(box.rotation), ','));
-	lines.push(line(3, property('modifiers'), ': {'));
+	lines.push(line(3, property('modifiers'), ': ', brace(3, '{')));
 	lines.push(line(4, property('font'), ': ', string(box.modifiers.font), ','));
 	lines.push(line(4, property('fontSize'), ': ', number(box.modifiers.fontSize), ','));
 	lines.push(line(4, property('allCaps'), ': ', boolean(box.modifiers.allCaps), ','));
@@ -71,8 +76,8 @@ function addBox(lines: JSX.Element[], box: EntryBox, last: boolean) {
 	lines.push(line(4, property('textAlign'), ': ', string(box.modifiers.textAlign), ','));
 	lines.push(line(4, property('verticalAlign'), ': ', string(box.modifiers.verticalAlign), ','));
 	lines.push(line(4, property('opacity'), ': ', number(box.modifiers.opacity)));
-	lines.push(line(3, '}'));
-	lines.push(line(2, last ? '}' : '},'));
+	lines.push(line(3, brace(3, '}')));
+	lines.push(line(2, ...(last ? [brace(2, '}')] : [brace(2, '}'), ','])));
 }
 
 function addBoxes(lines: JSX.Element[], boxes: readonly EntryBox[]) {
@@ -82,40 +87,45 @@ function addBoxes(lines: JSX.Element[], boxes: readonly EntryBox[]) {
 }
 
 function renderJson() {
+	const url = (
+		<nuxt-link target="_blank" href={props.url} class="underline">
+			{props.url}
+		</nuxt-link>
+	);
 	const lines = [
-		line(0, '{'),
+		line(0, brace(0, '{')),
 		line(1, property('name'), ': ', string(props.name), ','),
-		line(1, property('url'), ': ', string(props.url), ','),
-		line(1, property('avatars'), ': {')
+		line(1, property('url'), ': ', string(url), ','),
+		line(1, property('avatars'), ': ', brace(1, '{'))
 	];
 
 	if (props.avatars.author.length === 0) {
-		lines.push(line(2, property('author'), ': [],'));
+		lines.push(line(2, property('author'), ': ', brace(2, '[]'), ','));
 	} else {
-		lines.push(line(2, property('author'), ': ['));
+		lines.push(line(2, property('author'), ': ', brace(2, '[')));
 		addAvatars(lines, props.avatars.author);
-		lines.push(line(2, '],'));
+		lines.push(line(2, brace(2, ']'), ','));
 	}
 
 	if (props.avatars.target.length === 0) {
-		lines.push(line(2, property('target'), ': []'));
+		lines.push(line(2, property('target'), ': ', brace(2, '[]')));
 	} else {
-		lines.push(line(2, property('target'), ': ['));
+		lines.push(line(2, property('target'), ': ', brace(2, '[')));
 		addAvatars(lines, props.avatars.target);
-		lines.push(line(2, ']'));
+		lines.push(line(2, brace(2, ']')));
 	}
 
-	lines.push(line(1, '}'));
+	lines.push(line(1, brace(1, '}'), ','));
 
 	if (props.boxes.length === 0) {
-		lines.push(line(1, property('boxes'), ': []'));
+		lines.push(line(1, property('boxes'), ': ', brace(1, '[]')));
 	} else {
-		lines.push(line(1, property('boxes'), ': ['));
+		lines.push(line(1, property('boxes'), ': ', brace(1, '[')));
 		addBoxes(lines, props.boxes);
-		lines.push(line(1, ']'));
+		lines.push(line(1, brace(1, ']')));
 	}
 
-	lines.push(line(0, '}'));
+	lines.push(line(0, brace(0, '}')));
 	return <code>{lines}</code>;
 }
 </script>

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -1,5 +1,5 @@
 <template>
-	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status"><render-json /></pre>
+	<pre class="p-5 bg-gray-200 dark:bg-stone-900 rounded-xl h-[50vh] overflow-y-auto" role="status"><client-only><render-json /></client-only></pre>
 </template>
 
 <script setup lang="tsx">
@@ -116,10 +116,6 @@ function renderJson() {
 	}
 
 	lines.push(line(0, '}'));
-	return (
-		<code>
-			<client-only>{lines}</client-only>
-		</code>
-	);
+	return <code>{lines}</code>;
 }
 </script>

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -22,19 +22,19 @@ function line(indent: number, ...elements: readonly (JSX.Element | string)[]) {
 }
 
 function property(name: string) {
-	return <span class="text-teal-400">"{name}"</span>;
+	return <span class="text-teal-600 dark:text-teal-400">"{name}"</span>;
 }
 
 function string(value: string) {
-	return <span class="text-green-400">"{value}"</span>;
+	return <span class="text-green-600 dark:text-green-400">"{value}"</span>;
 }
 
 function number(value: number) {
-	return <span class="text-amber-400">{value}</span>;
+	return <span class="text-amber-600 dark:text-amber-400">{value}</span>;
 }
 
 function boolean(value: boolean) {
-	return <span class="text-rose-400">{value ? 'true' : 'false'}</span>;
+	return <span class="text-rose-600 dark:text-rose-400">{value ? 'true' : 'false'}</span>;
 }
 
 function addAvatar(lines: JSX.Element[], position: EntryAvatarPosition, last: boolean) {
@@ -116,6 +116,10 @@ function renderJson() {
 	}
 
 	lines.push(line(0, '}'));
-	return <code>{lines}</code>;
+	return (
+		<code>
+			<client-only>{lines}</client-only>
+		</code>
+	);
 }
 </script>

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -100,7 +100,7 @@ function renderJson() {
 	if (props.avatars.target.length === 0) {
 		lines.push(line(2, property('target'), ': []'));
 	} else {
-		lines.push(line(2, property('target'), ': []'));
+		lines.push(line(2, property('target'), ': ['));
 		addAvatars(lines, props.avatars.target);
 		lines.push(line(2, ']'));
 	}

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -17,7 +17,7 @@ export interface EntryAvatarPosition {
 	rotation: number;
 }
 
-interface EntryBoxModifiers {
+export interface EntryBoxModifiers {
 	font: 'impact' | 'arial';
 	fontSize: number;
 	allCaps: boolean;

--- a/pages/[...id].vue
+++ b/pages/[...id].vue
@@ -245,7 +245,7 @@
 	</div>
 
 	<hr class="json-divider" />
-	<codeblock :data="{ name, url, avatars, boxes }" />
+	<codeblock :name="name" :url="url" :avatars="avatars" :boxes="boxes" />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
At first, we tried shiki in #18, however, the library tried to load a WASM file (which isn't available in Cloudflare Pages) and on the client, it tried to load over 160 JSON files alongside a +580 KB Wasm file, making the website take over 6 seconds on somewhat decent internet.

This is a TSX approach with hardcoded object shapes (as agreed internally) using Vue's function renderers. The reason why I went for a function render is so I could make "macros" (functions expanding to more code) rather than writing all the code manually, and TSX is to make the code a lot simpler, as `h('span', { class: '...' }, ['Foo'])` is more verbose and less readable than `<span class="...">Foo</span>`.

This approach is lightning fast and library-less while it leverages the styles from the website (and it's highly customizable!).
