### PR TITLE
fix(a11y,seo): switch JSON `url` to a simple `span`

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -22,7 +22,7 @@
 		@apply bg-gray-200 hover:bg-gray-300 dark:bg-stone-900 hover:dark:bg-stone-800 rounded-xl;
 	}
 
-	.base-input:not([type="range"]) {
+	.base-input:not([type='range']) {
 		@apply border-2 p-2 bg-gray-100 border-gray-300 dark:border-stone-700 dark:bg-stone-900;
 	}
 

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -87,11 +87,7 @@ function addBoxes(lines: JSX.Element[], boxes: readonly EntryBox[]) {
 }
 
 function renderJson() {
-	const url = (
-		<a target="_blank" href={props.url} rel="noopener noreferrer" class="underline" aria-label="The URL used for the meme template, if any">
-			{props.url}
-		</a>
-	);
+	const url = <span class="underline">{props.url}</span>;
 	const lines = [
 		line(0, brace(0, '{')),
 		line(1, property('name'), ': ', string(props.name), ','),

--- a/components/codeblock.vue
+++ b/components/codeblock.vue
@@ -88,7 +88,7 @@ function addBoxes(lines: JSX.Element[], boxes: readonly EntryBox[]) {
 
 function renderJson() {
 	const url = (
-		<a target="_blank" href={props.url} rel="noopener noreferrer" class="underline">
+		<a target="_blank" href={props.url} rel="noopener noreferrer" class="underline" aria-label="The URL used for the meme template, if any">
 			{props.url}
 		</a>
 	);


### PR DESCRIPTION
I tried to make it alternate between `<a>` and `<span>` based on whether or not the link was valid, however, it seems it cannot dynamically switch between element types even inside computed, probably a limitation from TSX or its support, despite the render function being called as expected.
